### PR TITLE
fix: interface member order enums

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solhint-plugin-defi-wonderland",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "DeFi Wonderland's best practices Solhint plugin",
   "keywords": [
     "solhint",

--- a/rules/interface-member-order.ts
+++ b/rules/interface-member-order.ts
@@ -28,29 +28,22 @@ export class InterfaceMemberOrderChecker extends BaseChecker implements Rule {
     const enums: any[] = [];
     const functions: any[] = [];
 
-    interfaceMembers.forEach((member: any) => {
-      switch (member.type) {
-        case 'EventDefinition':
-          unOrderedMembers.push(member);
-          events.push(member);
-          break;
-        case 'CustomErrorDefinition':
-          unOrderedMembers.push(member);
-          errors.push(member);
-          break;
-        case 'EnumDefinition':
-          unOrderedMembers.push(member);
-          enums.push(member);
-        case 'StructDefinition':
-          unOrderedMembers.push(member);
-          structs.push(member);
-          break;
-        case 'FunctionDefinition':
-          unOrderedMembers.push(member);
-          functions.push(member);
-          break;
-        default:
-          break;
+    interfaceMembers.forEach((member) => {
+      if (member.type === 'EventDefinition') {
+        unOrderedMembers.push(member);
+        events.push(member);
+      } else if (member.type === 'CustomErrorDefinition') {
+        unOrderedMembers.push(member);
+        errors.push(member);
+      } else if (member.type === 'EnumDefinition') {
+        unOrderedMembers.push(member);
+        enums.push(member);
+      } else if (member.type === 'StructDefinition') {
+        unOrderedMembers.push(member);
+        structs.push(member);
+      } else if (member.type === 'FunctionDefinition') {
+        unOrderedMembers.push(member);
+        functions.push(member);
       }
     });
 

--- a/test/rules/interface-member-order.ts
+++ b/test/rules/interface-member-order.ts
@@ -51,7 +51,12 @@ describe('Linter - interface-member-order', () => {
   it('should not raise error for interface member order events, errors, enums, structs, and functions', () => {
     const code = interfaceWith(
       interfaceName,
-      'event TestEvent(); error TestError(); enum TestEnum { A, B } struct TestStruct { uint256 data; } function testFunction(){}'
+      `event TestEvent(); event TestEvent2();
+       error TestError(); error TestError2();
+       enum TestEnum { A, B } enum TestEnum2 { A, B }
+       struct TestStruct { uint256 data; } struct TestStruct2 { uint256 data; }
+       function testFunction(){} function testFunction2(){}
+      `
     );
     const report = processStr(code, config);
 

--- a/test/rules/interface-member-order.ts
+++ b/test/rules/interface-member-order.ts
@@ -11,7 +11,13 @@ const errorMessage = `The order of members in the interface ${interfaceName} int
 
 describe('Linter - interface-member-order', () => {
   it('should raise error when errors first than events', () => {
-    const code = interfaceWith(interfaceName, 'error TestError(); event TestEvent();');
+    const code = interfaceWith(
+      interfaceName,
+      `
+        error TestError(); error TestError2(); 
+        event TestEvent(); event TestEvent2();
+      `
+    );
     const report = processStr(code, config);
 
     assert.equal(report.errorCount, 1);
@@ -19,7 +25,13 @@ describe('Linter - interface-member-order', () => {
   });
 
   it('should raise error when structs first than errors', () => {
-    const code = interfaceWith(interfaceName, 'struct TestStruct { uint256 data; } error Error();');
+    const code = interfaceWith(
+      interfaceName,
+      `
+        struct TestStruct { uint256 data; } struct TestStruct2 { uint256 data; }
+        error Error(); error Error2();
+      `
+    );
     const report = processStr(code, config);
 
     assert.equal(report.errorCount, 1);
@@ -27,14 +39,26 @@ describe('Linter - interface-member-order', () => {
   });
 
   it('should raise error when structs first than enums', () => {
-    const code = interfaceWith(interfaceName, 'struct TestStruct { uint256 data; } enum TestEnum { A, B }');
+    const code = interfaceWith(
+      interfaceName,
+      `
+        struct TestStruct { uint256 data; } struct TestStruct2 { uint256 data; }
+        enum TestEnum { A, B } enum TestEnum2 { A, B }
+      `
+    );
     const report = processStr(code, config);
     assert.equal(report.errorCount, 1);
     assert.ok(report.messages[0].message == errorMessage);
   });
 
   it('should raise error when functions first than structs', () => {
-    const code = interfaceWith(interfaceName, 'function testFunction(){} struct TestStruct { uint256 data; }');
+    const code = interfaceWith(
+      interfaceName,
+      `
+        function testFunction(){} function testFunction2(){}
+        struct TestStruct { uint256 data; } struct TestStruct2 { uint256 data; }
+      `
+    );
     const report = processStr(code, config);
 
     assert.equal(report.errorCount, 1);
@@ -42,7 +66,13 @@ describe('Linter - interface-member-order', () => {
   });
 
   it('should raise an error when function first than enums', () => {
-    const code = interfaceWith(interfaceName, 'function testFunction(){} enum TestEnum { A, B }');
+    const code = interfaceWith(
+      interfaceName,
+      `
+        function testFunction(){} function testFunction2(){} 
+        enum TestEnum { A, B } enum TestEnum2 { A, B }
+      `
+    );
     const report = processStr(code, config);
     assert.equal(report.errorCount, 1);
     assert.ok(report.messages[0].message == errorMessage);
@@ -51,11 +81,12 @@ describe('Linter - interface-member-order', () => {
   it('should not raise error for interface member order events, errors, enums, structs, and functions', () => {
     const code = interfaceWith(
       interfaceName,
-      `event TestEvent(); event TestEvent2();
-       error TestError(); error TestError2();
-       enum TestEnum { A, B } enum TestEnum2 { A, B }
-       struct TestStruct { uint256 data; } struct TestStruct2 { uint256 data; }
-       function testFunction(){} function testFunction2(){}
+      `
+        event TestEvent(); event TestEvent2();
+        error TestError(); error TestError2();
+        enum TestEnum { A, B } enum TestEnum2 { A, B }
+        struct TestStruct { uint256 data; } struct TestStruct2 { uint256 data; }
+        function testFunction(){} function testFunction2(){}
       `
     );
     const report = processStr(code, config);


### PR DESCRIPTION
When having multiple enums and structs, the rule was being falsely triggered. 
The error consisted on the switch cases, the case `StructDefinition` to be precise.
When the case was entered, it was adding `EnumDefinition` as a struct member.
So after that, when doing the `.find` filter, it was finding a duplicate of the enum in the array, using a wrong index.

Example of wrong enums inside the `structs` array:
![image](https://github.com/defi-wonderland/solhint-plugin/assets/78362532/83df9f69-b8fe-4f07-934e-fa131fd56b56)

Example of duplicated enums in the `orderedMembers` / `unOrderedMembers` array 
![image](https://github.com/defi-wonderland/solhint-plugin/assets/78362532/b3265fb5-71c0-4856-a0a4-3933993b7949)

This fix elimintates the duplicated enums.
